### PR TITLE
e2e fix: The kind image name is wrong.

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -155,7 +155,7 @@ setup_kind:
   		fi
 	$(QUIET) cat $(CLUSTER_DIR)/$(E2E_CLUSTER_NAME)/kind-config.yaml
 	KIND_OPTION="" ; \
-       		[ -n "$(E2E_KIND_NODE_IMAGE)" ] && KIND_OPTION=" --image $(E2E_KIND_NODE_IMAGE) " && echo "setup kind with E2E_KIND_NODE_IMAGE=$(E2E_KIND_NODE_IMAGE)"; \
+       		[ -n "$(E2E_KIND_IMAGE_TAG)" ] && KIND_OPTION=" --image $(E2E_KIND_IMAGE_NAME):$(E2E_KIND_IMAGE_TAG) " && echo "setup kind with $(E2E_KIND_IMAGE_NAME):$(E2E_KIND_IMAGE_TAG)"; \
             kind create cluster --config $(CLUSTER_DIR)/$(E2E_CLUSTER_NAME)/kind-config.yaml \
 			--name $(E2E_CLUSTER_NAME) --kubeconfig $(E2E_KUBECONFIG) $${KIND_OPTION}
 	- kubectl --kubeconfig $(E2E_KUBECONFIG) taint nodes --all node-role.kubernetes.io/master- || true


### PR DESCRIPTION
robot cherry pick PR <https://github.com/ty-dc/spiderpool/pull/68> from <ty-dc>,to branch <release-v0.9>,  action <https://github.com/ty-dc/spiderpool/actions/runs/7485106973>  , commits a1f987f235432951ff3d4fa5f6b8d9f7dfa4df33